### PR TITLE
Sprint5 task4

### DIFF
--- a/app/controllers/admins/employees_controller.rb
+++ b/app/controllers/admins/employees_controller.rb
@@ -18,6 +18,28 @@ module Admins
       end
     end
 
+    def edit_kudos_to_all
+      @employees = Employee.all
+      render 'admins/employees/add_kudos_to_all'
+    end
+
+    def add_kudos_to_all
+      new_amount_of_kudos = amount_params
+      if new_amount_of_kudos < 21
+        Employee.transaction do
+          Employee.find_each do |employee|
+            employee.update!(number_of_available_kudos: employee.number_of_available_kudos + new_amount_of_kudos)
+          end
+        flash[:notice] = "Successfully added the specified amount of kudos for each employee"
+        redirect_to admins_dashboard_path
+
+        rescue ActiveRecord::RecordInvalid
+          flash[:alert] = "It's possible to only add kudos from 1 to 20 for each employee"
+          render 'add_kudos_to_all'
+        end
+      end
+    end
+
     def destroy
       @employee = Employee.find(params[:id])
       if @employee.destroy
@@ -32,6 +54,10 @@ module Admins
 
     def employee_params
       params.require(:employee).permit(:email, :password, :number_of_available_kudos)
+    end
+
+    def amount_params
+      params[:amount].to_i
     end
   end
 end

--- a/app/controllers/admins/employees_controller.rb
+++ b/app/controllers/admins/employees_controller.rb
@@ -37,9 +37,6 @@ module Admins
           flash[:alert] = "It's possible to only add kudos from 1 to 20 for each employee"
           render 'add_kudos_to_all'
         end
-      else
-        flash[:alert] = "It's possible to only add kudos from 1 to 20 for each employee"
-        render 'add_kudos_to_all'
       end
     end
 

--- a/app/controllers/admins/employees_controller.rb
+++ b/app/controllers/admins/employees_controller.rb
@@ -37,7 +37,7 @@ module Admins
           flash[:alert] = "It's possible to only add kudos from 1 to 20 for each employee"
           render 'add_kudos_to_all'
         end
-      else 
+      else
         flash[:alert] = "It's possible to only add kudos from 1 to 20 for each employee"
         render 'add_kudos_to_all'
       end

--- a/app/controllers/admins/employees_controller.rb
+++ b/app/controllers/admins/employees_controller.rb
@@ -38,7 +38,6 @@ module Admins
         end
       else
         flash[:alert] = "It's possible to only add kudos from 1 to 20 for each employee"
-        render 'add_kudos_to_all'
       end
     end
 

--- a/app/controllers/admins/employees_controller.rb
+++ b/app/controllers/admins/employees_controller.rb
@@ -30,13 +30,16 @@ module Admins
           Employee.find_each do |employee|
             employee.update!(number_of_available_kudos: employee.number_of_available_kudos + new_amount_of_kudos)
           end
-        flash[:notice] = "Successfully added the specified amount of kudos for each employee"
-        redirect_to admins_dashboard_path
+          flash[:notice] = 'Successfully added the specified amount of kudos for each employee'
+          redirect_to admins_dashboard_path
 
         rescue ActiveRecord::RecordInvalid
           flash[:alert] = "It's possible to only add kudos from 1 to 20 for each employee"
           render 'add_kudos_to_all'
         end
+      else 
+        flash[:alert] = "It's possible to only add kudos from 1 to 20 for each employee"
+        render 'add_kudos_to_all'
       end
     end
 

--- a/app/controllers/admins/employees_controller.rb
+++ b/app/controllers/admins/employees_controller.rb
@@ -32,11 +32,13 @@ module Admins
           end
           flash[:notice] = 'Successfully added the specified amount of kudos for each employee'
           redirect_to admins_dashboard_path
-
         rescue ActiveRecord::RecordInvalid
           flash[:alert] = "It's possible to only add kudos from 1 to 20 for each employee"
           render 'add_kudos_to_all'
         end
+      else
+        flash[:alert] = "It's possible to only add kudos from 1 to 20 for each employee"
+        render 'add_kudos_to_all'
       end
     end
 

--- a/app/views/admins/employees/_employees_table.html.erb
+++ b/app/views/admins/employees/_employees_table.html.erb
@@ -1,0 +1,23 @@
+<table class="table table-dark table-striped">
+  <thead>
+    <tr>
+      <th>Email</th>
+      <th>Number of available Kudo</th>
+      <th>Update</th>
+      <th>Delete</th>
+      <th>Orders</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @employees.each do |employee| %>
+      <tr>
+        <td><%= employee.email %></td>
+        <td><%= employee.number_of_available_kudos %></td>
+        <td><%= link_to "Edit", edit_admins_employee_path(employee), class: "btn btn-outline-warning" %></td>
+        <td><%= link_to "Delete Employee", admins_employee_path(employee), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-outline-danger" %></td>
+        <td><%= link_to "Show Employee Orders", admins_employee_orders_path(employee), class: "btn btn-outline-secondary" %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admins/employees/add_kudos_to_all.html.erb
+++ b/app/views/admins/employees/add_kudos_to_all.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_with url: 'add_kudos_to_all', method: :patch do |f| %>
   <%= f.label :amount, class: "form-label" %>
-  <%= f.number_field :amount, in: 1..20, value: 1, class: "form-control mb-2" %>
+  <%= f.number_field :amount, value: 1, class: "form-control mb-2" %>
   <%= f.submit "Add", class: "btn btn-outline-dark mb-4" %>
 <% end %>
 

--- a/app/views/admins/employees/add_kudos_to_all.html.erb
+++ b/app/views/admins/employees/add_kudos_to_all.html.erb
@@ -3,7 +3,6 @@
 <%= form_with url: 'add_kudos_to_all', method: :patch do |f| %>
   <%= f.label :amount, class: "form-label" %>
   <%= f.number_field :amount, in: 1..20, value: 1, class: "form-control mb-2" %>
-  <%= f.submit "Add points", class: "btn btn-outline-dark mb-4" %>
+  <%= f.submit "Add", class: "btn btn-outline-dark mb-4" %>
 <% end %>
 
-<%= render "employees_table.html.erb" %>

--- a/app/views/admins/employees/add_kudos_to_all.html.erb
+++ b/app/views/admins/employees/add_kudos_to_all.html.erb
@@ -1,0 +1,9 @@
+<h1 class="mb-3">Editing Employees Kudos Amount</h1>
+
+<%= form_with url: 'add_kudos_to_all', method: :patch do |f| %>
+  <%= f.label :amount, class: "form-label" %>
+  <%= f.number_field :amount, in: 1..20, value: 1, class: "form-control mb-2" %>
+  <%= f.submit "Add points", class: "btn btn-outline-dark mb-4" %>
+<% end %>
+
+<%= render "employees_table.html.erb" %>

--- a/app/views/admins/employees/index.html.erb
+++ b/app/views/admins/employees/index.html.erb
@@ -1,3 +1,3 @@
 <h1>Employees List</h1>
 
-<%= render "employees_table.html.erb"%>
+<%= render "employees_table.html.erb" %>

--- a/app/views/admins/employees/index.html.erb
+++ b/app/views/admins/employees/index.html.erb
@@ -1,25 +1,3 @@
 <h1>Employees List</h1>
 
-<table class="table table-dark table-striped">
-  <thead>
-    <tr>
-      <th>Email</th>
-      <th>Number of available Kudo</th>
-      <th>Update</th>
-      <th>Delete</th>
-      <th>Orders</th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <% @employees.each do |employee| %>
-      <tr>
-        <td><%= employee.email %></td>
-        <td><%= employee.number_of_available_kudos %></td>
-        <td><%= link_to "Edit", edit_admins_employee_path(employee), class: "btn btn-outline-warning" %></td>
-        <td><%= link_to "Delete Employee", admins_employee_path(employee), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-outline-danger" %></td>
-        <td><%= link_to "Show Employee Orders", admins_employee_orders_path(employee), class: "btn btn-outline-secondary" %></td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<%= render "employees_table.html.erb"%>

--- a/app/views/shared/_navbar_admin.html.erb
+++ b/app/views/shared/_navbar_admin.html.erb
@@ -18,6 +18,9 @@
       </ul>
       <ul class="navbar-nav">
         <li class="nav-item ms-1">
+          <%= link_to 'Add Kudos', admins_add_kudos_to_all_path, class: "btn btn-success btn-sm" %>
+        </li>
+        <li class="nav-item ms-1">
           <%= link_to 'Kudos', admins_kudos_path, class: "btn btn-primary btn-sm" %>
         </li>
         <li class="nav-item ms-1">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,9 @@ Rails.application.routes.draw do
   end
   namespace :admins do
     get '/dashboard', to: 'pages#dashboard'
+    
+    get 'add_kudos_to_all', to: 'employees#edit_kudos_to_all'
+    patch 'add_kudos_to_all', to: 'employees#add_kudos_to_all'
     resources :kudos
     resources :employees, only: [:index, :edit, :update, :destroy] do
       resources :orders, only: [:index, :update]

--- a/spec/system/admin/admin_add_kudos_to_all_spec.rb
+++ b/spec/system/admin/admin_add_kudos_to_all_spec.rb
@@ -11,11 +11,9 @@ RSpec.describe 'add kudos to every employee', type: :system do
     click_link 'Add Kudos'
     fill_in 'amount',	with: 3
     click_button 'Add'
-    employee1.reload
-    employee2.reload
     expect(page).to have_text 'Successfully added the specified amount of kudos for each employee'
-    expect(employee1.number_of_available_kudos).to eq(13)
-    expect(employee2.number_of_available_kudos).to eq(13)
+    expect(employee1.reload.number_of_available_kudos).to eq(13)
+    expect(employee2.reload.number_of_available_kudos).to eq(13)
   end
 
   it 'checks if the constrains on the number of available kudos field work' do

--- a/spec/system/admin/admin_add_kudos_to_all_spec.rb
+++ b/spec/system/admin/admin_add_kudos_to_all_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe 'add kudos to every employee', type: :system do
+  let!(:admin) { create :admin }
+  let!(:employee1) { create :employee }
+  let!(:employee2) { create :employee }
+
+  it 'checks if the add kudo to all feature is working' do
+    login_as(admin, scope: :admin)
+    visit admins_dashboard_path
+    click_link 'Add Kudos'
+    fill_in 'amount',	with: 3
+    click_button 'Add'
+    employee1.reload
+    employee2.reload
+    expect(page).to have_text 'Successfully added the specified amount of kudos for each employee'
+    expect(employee1.number_of_available_kudos).to eq(13)
+    expect(employee2.number_of_available_kudos).to eq(13)
+  end
+
+  it 'checks if the constrains on the number of available kudos field work' do
+    login_as(admin, scope: :admin)
+    visit admins_dashboard_path
+    click_link 'Add Kudos'
+    fill_in 'amount',	with: 30
+    click_button 'Add'
+    expect(page).to have_text "It's possible to only add kudos from 1 to 20 for each employee"
+  end
+end


### PR DESCRIPTION
- Add "Add Kudos" link in the admin panel
- "Add Kudos" form has one numerical input for the number of kudos.
- The number of kudos in the "Add Kudos" form has to be between 1 and 20.
- Submitting the "Add Kudos" form adds the same number of kudos to the `number_of_available_kudos` field of each employee.
- After successfully submitting the "Add Kudos" form, admin sees a flash message with a confirmation.